### PR TITLE
Added Gruntfile for zip build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+zips

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,74 @@
+module.exports = function(grunt) {
+
+  grunt.initConfig({
+	pkg: grunt.file.readJSON('package.json'),
+	banner: '/*!\n' +
+		'* Backbone.CollectionView, v<%= pkg.version %>\n' +
+		'* Copyright (c)2013 Rotunda Software, LLC.\n' +
+		'* Distributed under MIT license\n' +
+		'* http://github.com/rotundasoftware/backbone-collection-view\n' +
+		'*/\n\n',
+
+	// Task configuration.
+	concat: {
+		options: {
+			banner: '<%= banner %>',
+			stripBanners: true
+		},
+		dist: {
+			src: ['src/<%= pkg.name %>.js'],
+			dest: 'dist/<%= pkg.name %>.js'
+		}
+	},
+	uglify: {
+		options: {
+			banner: '<%= banner %>'
+		},
+		dist: {
+			src: '<%= concat.dist.dest %>',
+			dest: 'dist/<%= pkg.name %>.min.js'
+		}
+	},
+	compress: {
+		dist: {
+			options: {
+				archive: 'zips/Backbone.CollectionView.zip'
+			},
+			expand: true,
+			cwd: 'dist/',
+			src: ['**/*'],
+			dest: './'
+		}
+	},
+	jshint: {
+		options: {
+			curly: true,
+			eqeqeq: true,
+			immed: true,
+			latedef: true,
+			newcap: true,
+			noarg: true,
+			sub: true,
+			undef: true,
+			unused: true,
+			boss: true,
+			eqnull: true,
+			browser: true,
+			globals: {
+				jQuery: true
+			}
+		},
+		library: {
+			src: 'collectionView.js'
+		}
+	}
+});
+
+	grunt.loadNpmTasks('grunt-contrib-concat');
+	grunt.loadNpmTasks('grunt-contrib-uglify');
+	grunt.loadNpmTasks('grunt-contrib-jshint');
+	grunt.loadNpmTasks('grunt-contrib-compress');
+
+	grunt.registerTask('default', ['concat', 'uglify', 'compress']);
+
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "Backbone.CollectionView",
+	"version": "0.4.6",
+	"description": "A backbone view class that renders a collection of models. This class is similar to the collection view classes found in [Backbone.Marionette](https://github.com/marionettejs/backbone.marionette) and other frameworks, with added features for automatic selection of models in response to clicks, and support for rearranging models (and reordering the underlying collection) through drag and drop.",
+	"main": "Gruntfile.js",
+	"devDependencies": {
+		"grunt": "~0.4.1",
+		"grunt-contrib-concat": "~0.2.0",
+		"grunt-contrib-uglify": "~0.2.0",
+		"grunt-contrib-jshint": "~0.4.3",
+		"grunt-contrib-compress": "~0.4.10"
+	},
+	"scripts": {
+		"test": "open test/index.html"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/rotundasoftware/backbone-collection-view.git"
+	},
+	"author": {
+		"name" : "Rotunda Software"
+	},
+	"license": "MIT",
+	"readmeFilename": "README.md"
+}

--- a/src/Backbone.CollectionView.js
+++ b/src/Backbone.CollectionView.js
@@ -1,10 +1,3 @@
-/*!
- * Backbone.CollectionView, v0.4.6
- * Copyright (c)2013 Rotunda Software, LLC.
- * Distributed under MIT license
- * http://github.com/rotundasoftware/backbone-collection-view
-*/
-
 (function(){
 	var mDefaultModelViewConstructor = Backbone.View;
 

--- a/test/index.html
+++ b/test/index.html
@@ -10,7 +10,7 @@
 <script type="text/javascript" src="lib/underscore.js"></script>
 <script type="text/javascript" src="lib/backbone.js"></script>
 <script type="text/javascript" src="lib/backbone.babysitter.js"></script>
-<script type="text/javascript" src="../collectionView.js"></script>
+<script type="text/javascript" src="../src/Backbone.CollectionView.js"></script>
 <script type="text/javascript"src="lib/qunit-1.11.0.js"></script>
 <script type="text/javascript" src="tests.js"></script>
 </head>


### PR DESCRIPTION
I set up a basic grunt build process to create the downloaded zip for the gh-page.  Run 

```
npm install && grunt
```

to build the zip.  I still have to make the CSS file and include it in the zip. It would be nice to include the dependencies in a `dependencies` folder within the zip so users can get the versions of the dependencies that the library is tested with.

I also added a grunt task for jshint, which can be used to help maintain code style consistency. I spent a little time trying to set up continuous integration but I was having trouble with running qunit inside phantomjs, Ill try to get it working tomorrow.
