### PR TITLE
Improved selection events and handling for preserving the selection when the last element gets deleted

### DIFF
--- a/src/backbone.collectionView.js
+++ b/src/backbone.collectionView.js
@@ -604,9 +604,15 @@
 				// all the items with the saved reference ids have been removed from the list.
 				// ok. try to restore the selection based on the offset that used to be selected.
 				// this is the expected behavior after a item is deleted from a list (i.e. select
-				// the line that immediately follows the deleted line).
+				// the line that immediately follows the deleted line or the last item 
+                // if the last item was selected).
 				if( this.selectedItems.length === 0 )
-					this.setSelectedModel( this.savedSelection.offset, { by : "offset" } );
+				{
+                    var targetOffset = ( this.savedSelection.offset >= this.collection.length ) ?
+                        this.collection.length - 1 :
+				        this.savedSelection.offset;
+                    this.setSelectedModel( targetOffset, { by : "offset" } );
+                }
 			}
             
             // Trigger a selection changed if the previously selected items were not all found

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,9 +1,10 @@
 $(document).ready( function() {
 
+    var Employee = Backbone.Model.extend( { } );
+    var Employees = Backbone.Collection.extend( { model : Employee } );
+    
 	function commonSetup() {
 
-		var Employee = Backbone.Model.extend( { } );
-		var Employees = Backbone.Collection.extend( { model : Employee } );
 		this.emp1 = new Employee( { id : 1, firstName : 'Sherlock', lastName : 'Holmes' } );
 		this.emp2 = new Employee( { id : 2, firstName : 'John', lastName : 'Watson' } );
 		this.emp3 = new Employee( { id : 3, firstName : 'Mycroft', lastName : 'Holmes' } );
@@ -863,6 +864,102 @@ $(document).ready( function() {
 		emp2View.$el.dblclick();
 
 	} );
+
+    test( "collection add preserves selection", 1, function() {
+
+        var myCollectionView = new Backbone.CollectionView( {
+            el : this.$collectionViewEl,
+            collection : this.employees,
+            modelView : this.EmployeeView,
+            selectable : true
+        } );
+
+        myCollectionView.render();
+
+        myCollectionView.setSelectedModel( this.emp2 );
+
+        this.emp4 = new Employee( { id : 4, firstName : 'Tracy', lastName : 'Johnson' } );
+        this.employees.add( this.emp4 );
+
+        var selectedCid = myCollectionView.getSelectedModel( { by : "cid" } );
+        equal( selectedCid, this.emp2.cid, "Selected item is the correct cid" );
+    } );
+
+    test( "collection remove preserves selection", 1, function() {
+
+        var myCollectionView = new Backbone.CollectionView( {
+            el : this.$collectionViewEl,
+            collection : this.employees,
+            modelView : this.EmployeeView,
+            selectable : true
+        } );
+
+        myCollectionView.render();
+
+        myCollectionView.setSelectedModel( this.emp2 );
+
+        this.employees.remove( this.emp3 );
+
+        var selectedCid = myCollectionView.getSelectedModel( { by : "cid" } );
+        equal( selectedCid, this.emp2.cid, "Selected item is the correct cid" );
+    } );
+
+    test( "collection remove when selected model is removed", 1, function() {
+
+        var myCollectionView = new Backbone.CollectionView( {
+            el : this.$collectionViewEl,
+            collection : this.employees,
+            modelView : this.EmployeeView,
+            selectable : true,
+        } );
+
+        myCollectionView.render();
+
+        myCollectionView.setSelectedModel( this.emp3 );
+
+        this.employees.remove( this.emp3 );
+
+        var selectedCid = myCollectionView.getSelectedModel( { by : "cid" } );
+        equal( selectedCid, this.emp2.cid, "Selected item is the correct cid" );
+    } );
+
+    test( "collection reset preserves selection", 1, function() {
+
+        var myCollectionView = new Backbone.CollectionView( {
+            el : this.$collectionViewEl,
+            collection : this.employees,
+            modelView : this.EmployeeView,
+            selectable : true
+        } );
+
+        myCollectionView.render();
+
+        myCollectionView.setSelectedModel( this.emp2 );
+
+        this.employees.reset( [this.emp2, this.emp3] );
+
+        var selectedCid = myCollectionView.getSelectedModel( { by : "cid" } );
+        equal( selectedCid, this.emp2.cid, "Selected item is the correct cid" );
+    } );
+
+    test( "collection reset when the selected model is removed", 1, function() {
+
+        var myCollectionView = new Backbone.CollectionView( {
+            el : this.$collectionViewEl,
+            collection : this.employees,
+            modelView : this.EmployeeView,
+            selectable : true
+        } );
+
+        myCollectionView.render();
+
+        myCollectionView.setSelectedModel( this.emp3 );
+
+        this.employees.reset( [this.emp1, this.emp2] );
+
+        var selectedCid = myCollectionView.getSelectedModel( { by : "cid" } );
+        equal( selectedCid, this.emp2.cid, "Selected item is the correct cid" );
+    } );
 
 	module( "Empty List Caption",
 		{


### PR DESCRIPTION
Thanks for making this project available.  Here are 3 small improvements:

1) A small fix to be compatible with IE8 and lower
2) Improved handling for the selectionChanged event to avoid it firing too many times or occasionally not firing at all (when re-rendering)
3) Preserving the selection by offset when the last item is deleted.  The selection is already preserved when an item is deleted in the middle, but if the last item is deleted, then the new last item should be selected.

I have included tests for all the changes (except the IE8 one).

Please let me know if you have any questions.
