### PR TITLE
Ensures selectionChanged trigger fires atomically

### DIFF
--- a/src/backbone.collectionView.js
+++ b/src/backbone.collectionView.js
@@ -89,13 +89,13 @@
 				} );
 
 				this.listenTo( this.collection, "remove", function() {
-					this._validateSelectionAndRender();
+					this.render();
 					if( this._isBackboneCourierAvailable() )
 						this.spawn( "remove" );
 				} );
 
 				this.listenTo( this.collection, "reset", function() {
-					this._validateSelectionAndRender();
+					this.render();
 					if( this._isBackboneCourierAvailable() )
 						this.spawn( "reset" );
 				} );
@@ -567,7 +567,7 @@
 			if( this.savedSelection.items.length > 0 )
 			{
 				// first try to restore the old selected items using their reference ids.
-				this.setSelectedModels( this.savedSelection.items, { by : "cid" }, { silent : true } );
+				this.setSelectedModels( this.savedSelection.items, { by : "cid", silent : true } );
 
 				// all the items with the saved reference ids have been removed from the list.
 				// ok. try to restore the selection based on the offset that used to be selected.
@@ -575,6 +575,18 @@
 				// the line that immediately follows the deleted line).
 				if( this.selectedItems.length === 0 )
 					this.setSelectedModel( this.savedSelection.offset, { by : "offset" } );
+
+				// Trigger a selection changed if the previously selected items were not all found
+				if (this.selectedItems.length !== this.savedSelection.items.length)
+				{
+					this.trigger( "selectionChanged", this.getSelectedModels(), [] );
+					if( this._isBackboneCourierAvailable() ) {
+						this.spawn( "selectionChanged", {
+							selectedModels : this.selectedItems,
+							oldSelectedModels : this.savedSelection.items
+						} );
+					}
+				}
 			}
 
 			delete this.savedSelection;

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,9 +1,10 @@
 $(document).ready( function() {
 
+	var Employee = Backbone.Model.extend( { } );
+	var Employees = Backbone.Collection.extend( { model : Employee } );
+
 	function commonSetup() {
 
-		var Employee = Backbone.Model.extend( { } );
-		var Employees = Backbone.Collection.extend( { model : Employee } );
 		this.emp1 = new Employee( { id : 1, firstName : 'Sherlock', lastName : 'Holmes' } );
 		this.emp2 = new Employee( { id : 2, firstName : 'John', lastName : 'Watson' } );
 		this.emp3 = new Employee( { id : 3, firstName : 'Mycroft', lastName : 'Holmes' } );
@@ -688,6 +689,133 @@ $(document).ready( function() {
 
 	} );
 
+    asyncTest( "selectionChanged when re-rendering", 0, function() {
+
+        var myCollectionView = new Backbone.CollectionView( {
+            el : this.$collectionViewEl,
+            collection : this.employees,
+            modelView : this.EmployeeView,
+            selectable : true
+        } );
+
+        myCollectionView.render();
+
+        myCollectionView.setSelectedModel( this.emp1 );
+
+        var selectionChangedHandler = function( newSelectedModels, oldSelectedModels ) {
+            ok( false,  "This selectionChanged handler should not have been called because the selection can be restored intact. " );
+        };
+
+        myCollectionView.on( "selectionChanged", selectionChangedHandler );
+
+        myCollectionView.render();
+
+        setTimeout( function() { start(); }, 100 );
+
+    } );
+
+    asyncTest( "selectionChanged when selected item is removed", 2, function() {
+
+        var _this = this;
+
+        var myCollectionView = new Backbone.CollectionView( {
+            el : this.$collectionViewEl,
+            collection : this.employees,
+            modelView : this.EmployeeView,
+            selectable : true
+        } );
+
+        myCollectionView.render();
+
+        myCollectionView.setSelectedModel( this.emp1 );
+
+        var selectionChangedHandler = function( newSelectedModels, oldSelectedModels ) {
+
+            start();
+
+            equal( oldSelectedModels[0], null, "Old selected model is null since it is no longer available" );
+            equal( newSelectedModels[0], _this.emp2, "New selected model is correct" );
+
+            stop();
+
+        };
+
+        myCollectionView.on( "selectionChanged", selectionChangedHandler );
+
+        this.employees.remove( this.emp1 );
+
+        setTimeout( function() { start(); }, 100 );
+
+    } );
+
+    asyncTest( "selectionChanged when selected item is removed with selectMultiple", 3, function() {
+
+        var _this = this;
+
+        var myCollectionView = new Backbone.CollectionView( {
+            el : this.$collectionViewEl,
+            collection : this.employees,
+            modelView : this.EmployeeView,
+            selectable : true,
+            selectMultiple : true
+        } );
+
+        myCollectionView.render();
+
+        myCollectionView.setSelectedModels( [this.emp1, this.emp2] );
+
+        var selectionChangedHandler = function( newSelectedModels, oldSelectedModels ) {
+
+            start();
+
+            equal( oldSelectedModels[0], null, "Old selected model is null since it is no longer available" );
+            equal( newSelectedModels.length, 1, "New selected models contains one model" );
+            equal( newSelectedModels[0], _this.emp2, "New selected model is correct" );
+
+            stop();
+
+        };
+
+        myCollectionView.on( "selectionChanged", selectionChangedHandler );
+
+        this.employees.remove( this.emp1 );
+
+        setTimeout( function() { start(); }, 100 );
+
+    } );
+
+    asyncTest( "selectionChanged when selected item is removed and nothing to re-select", 2, function() {
+
+        var myCollectionView = new Backbone.CollectionView( {
+            el : this.$collectionViewEl,
+            collection : this.employees,
+            modelView : this.EmployeeView,
+            selectable : true
+        } );
+
+        myCollectionView.render();
+
+        myCollectionView.setSelectedModel( this.emp1 );
+
+        var selectionChangedHandler = function( newSelectedModels, oldSelectedModels ) {
+
+            start();
+
+            equal( oldSelectedModels[0], null, "Old selected model is null since it is no longer available" );
+            equal( newSelectedModels[0], null, "New selected model is null since there is nothing to select" );
+
+            stop();
+
+        };
+
+        myCollectionView.on( "selectionChanged", selectionChangedHandler );
+
+        this.employees.reset( [] );
+
+        setTimeout( function() { start(); }, 100 );
+
+    } );
+
 	asyncTest( "updateDependentControls", 1, function() {
 
 		var _this = this;
@@ -735,6 +863,102 @@ $(document).ready( function() {
 
 		emp2View.$el.dblclick();
 
+	} );
+
+    test( "collection add preserves selection", 1, function() {
+
+        var myCollectionView = new Backbone.CollectionView( {
+            el : this.$collectionViewEl,
+            collection : this.employees,
+            modelView : this.EmployeeView,
+            selectable : true
+        } );
+
+        myCollectionView.render();
+
+        myCollectionView.setSelectedModel( this.emp2 );
+
+        this.emp4 = new Employee( { id : 4, firstName : 'Tracy', lastName : 'Johnson' } );
+        this.employees.add( this.emp4 );
+
+        var selectedCid = myCollectionView.getSelectedModel( { by : "cid" } );
+        equal( selectedCid, this.emp2.cid, "Selected item is the correct cid" );
+    } );
+
+    test( "collection remove preserves selection", 1, function() {
+
+        var myCollectionView = new Backbone.CollectionView( {
+            el : this.$collectionViewEl,
+            collection : this.employees,
+            modelView : this.EmployeeView,
+            selectable : true
+        } );
+
+        myCollectionView.render();
+
+        myCollectionView.setSelectedModel( this.emp2 );
+
+        this.employees.remove( this.emp3 );
+
+        var selectedCid = myCollectionView.getSelectedModel( { by : "cid" } );
+        equal( selectedCid, this.emp2.cid, "Selected item is the correct cid" );
+    } );
+
+    test( "collection remove when selected model is removed", 1, function() {
+
+        var myCollectionView = new Backbone.CollectionView( {
+            el : this.$collectionViewEl,
+            collection : this.employees,
+            modelView : this.EmployeeView,
+            selectable : true
+        } );
+
+        myCollectionView.render();
+
+        myCollectionView.setSelectedModel( this.emp2 );
+
+        this.employees.remove( this.emp2 );
+
+        var selectedCid = myCollectionView.getSelectedModel( { by : "cid" } );
+        equal( selectedCid, this.emp3.cid, "Selected item is the correct cid" );
+    } );
+
+    test( "collection reset preserves selection", 1, function() {
+
+        var myCollectionView = new Backbone.CollectionView( {
+            el : this.$collectionViewEl,
+            collection : this.employees,
+            modelView : this.EmployeeView,
+            selectable : true
+        } );
+
+        myCollectionView.render();
+
+        myCollectionView.setSelectedModel( this.emp2 );
+
+        this.employees.reset( [this.emp2, this.emp3] );
+
+        var selectedCid = myCollectionView.getSelectedModel( { by : "cid" } );
+        equal( selectedCid, this.emp2.cid, "Selected item is the correct cid" );
+    } );
+
+    test( "collection reset when the selected model is removed", 1, function() {
+
+        var myCollectionView = new Backbone.CollectionView( {
+            el : this.$collectionViewEl,
+            collection : this.employees,
+            modelView : this.EmployeeView,
+            selectable : true
+        } );
+
+        myCollectionView.render();
+
+        myCollectionView.setSelectedModel( this.emp2 );
+
+        this.employees.reset( [this.emp1, this.emp3] );
+
+        var selectedCid = myCollectionView.getSelectedModel( { by : "cid" } );
+        equal( selectedCid, this.emp3.cid, "Selected item is the correct cid" );
 	} );
 
 	module( "Empty List Caption",


### PR DESCRIPTION
Hi David,

As we discussed in PR #22, this change is on the dev branch now, and is just the part that ensures "selectionChanged" events are triggered the right number of times.  While integrating this, I found you had indeed already added the `silent : true` option in `_restoreSelection`, though there was a minor syntax error caught by the new tests.

Please let me know if this works for you.

Thanks,

Tim
