### PR TITLE
Optimization using DocumentFragments 

### DIFF
--- a/src/backbone.collectionView.js
+++ b/src/backbone.collectionView.js
@@ -346,6 +346,7 @@
 					modelViewParentElement = this.$el;
 
 				modelViewParentElement.empty();
+                      		var fragmentContainer = document.createDocumentFragment();
 
 				this.collection.each( function( thisModel ) {
 					var thisModelViewConstructor = this._getModelViewConstructor( thisModel );
@@ -388,7 +389,7 @@
 						if( ! this.selectableModelsFilter.call( _this, thisModel ) )
 							thisModelViewWrapped.addClass( "not-selectable" );
 
-					modelViewParentElement.append( thisModelViewWrapped );
+                          		fragmentContainer.appendChild(thisModelViewWrapped[0]);
 
 					// we have to render the modelView after it has been put in context, as opposed to in the 
 					// initialize function of the modelView, because some rendering might be dependent on
@@ -408,6 +409,7 @@
 
 					this.viewManager.add( thisModelView );
 				}, this );
+                      		modelViewParentElement.append(fragmentContainer);
 			}
 
 			if( this.sortable )


### PR DESCRIPTION
I have noticed that when there are lots of collection views inside a view, the load is really high. I have a view that use 7 list, each one is a Collection View. Inside of each item of the list I have a table that it is again a Collection View of rows.
When I render the parent view it takes to me almost 3 seconds to load all in a modern browser.
So I did this modification to the code. But maybe there is another way to optimizate. I have got the times that It takes to each block. And my modification is fast. But my view with lots of Collection Views continue being slow. Maybe you could optimize other lines of your code knowing this little optimization.

Like Oz Katz describes in Avoiding Common Backbone Pitfalls appending collection views each time causes the DOM to reflow (meaning that the browser has to recalculate the position and size of every element in the DOM tree)
http://ozkatz.github.io/avoiding-common-backbonejs-pitfalls.html

In the case of IE there are a lot of difference with the current appends. But maybe It could be better, add htmls in an array and join it. But the difference with documentFragment is minimal. 

David Walsh also recommend document fragment http://tech.pro/tutorial/1254/9-ways-to-optimize-your-front-end-performance
