### PR TITLE
Wrap to <li/> only if element is't <li/>

### DIFF
--- a/src/backbone.collectionView.js
+++ b/src/backbone.collectionView.js
@@ -680,7 +680,12 @@
 			}
 			else if( this._isRenderedAsList() ) {
 				// if we are rendering the collection in a list, we need wrap each item in an <li></li> and set the data-model-cid
-				wrappedModelView = modelView.$el.wrapAll( "<li data-model-cid='" + modelView.model.cid + "'></li>" ).parent();
+				// if view already have <li></li>, we only need to add data-model-cid
+				if( modelView.$el.prop('tagName').toLowerCase() === 'li' ) {
+					wrappedModelView = modelView.$el.attr( 'data-model-cid', modelView.model.cid );
+				} else {
+					wrappedModelView = modelView.$el.wrapAll( "<li data-model-cid='" + modelView.model.cid + "'></li>" ).parent();
+				}
 			}
 
 			if( _.isFunction( this.sortableModelsFilter ) )


### PR DESCRIPTION
In some cases, it's not necessary to wrap element in `<li/>`. For example with this modelView:

``` javascript
var view = new Backbone.View.extend({
   tagName: 'li',
   render: function() {
      this.$el.html('some text');
   }
});
```

Rendered DOM will be:

``` html
<ul>
  <li data-model-cid="1">
    <li>some text</li>
  </li>
</ul>
```

So, my patch checks if we already have `<li/>` and only adds "data" attribute.
