### PR TITLE
fix: sortStop and reorder descriptions did not match with implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ CollectionViews `trigger` the following events on themselves. You can respond to
 * __"updateDependentControls"__ ( _selectedModels_ ) Fired whenever controls that are dependent on the selection should be updated (e.g. buttons that should be disabled on no selection). This event is always fired just after `selectionChanged` is fired. In addition, it is fired after rendering and sorting.
 * __"doubleClick"__ ( _clickedModel_ ) Fired when a model view is double clicked.
 * __"sortStart"__  Fired just as a model view is starting to be dragged. (Sortable collection lists only.)
-* __"sortStop"__  Fired when a drag is finished, but before the collection is reordered. (Sortable collection lists only.)
-* __"reorder"__  Fired after a drag is finished and after the collection is reordered. (Sortable collection lists only.)
+* __"sortStop"__  Fired after a drag is finished and after the collection is reordered. (Sortable collection lists only.)
+* __"reorder"__  Fired when a drag is finished, but before the collection is reordered. (Sortable collection lists only.)
 
 ##Styling
 


### PR DESCRIPTION
....

this.collection.sort() is called after reorder is spawned and before sortStop is spawned.
