### PR TITLE
New objects can be added to the 0 index

### DIFF
--- a/src/backbone.collectionView.js
+++ b/src/backbone.collectionView.js
@@ -399,7 +399,7 @@
 
 			if( parentElOrDocumentFragment.nodeType === 11 ) // if we are inserting into a document fragment, we need to use the DOM appendChild method
 				parentElOrDocumentFragment.appendChild( thisModelViewWrapped.get( 0 ) );
-			else if( ! _.isUndefined( atIndex ) && atIndex > 0 && atIndex < this.collection.length - 1 )
+			else if( ! _.isUndefined( atIndex ) && atIndex >= 0 && atIndex < this.collection.length - 1 )
 				parentElOrDocumentFragment.children().eq( atIndex ).before( thisModelViewWrapped );
 			else
 				parentElOrDocumentFragment.append( thisModelViewWrapped );


### PR DESCRIPTION
Objects can now be added to the list with atIndex = 0, making them the first item

Before, adding an item with the 0 index would not pass the check and it would be added to the end of the list. This is very noticeable if you drag many items between connected sortable lists.
