### PR TITLE
FIX: toggle functionality not work with underscore >1.6.0

### DIFF
--- a/src/backbone.collectionView.js
+++ b/src/backbone.collectionView.js
@@ -906,7 +906,7 @@
 				{
 					if( _.contains( this.selectedItems, clickedItemId ) )
 						this.setSelectedModels( _.without( this.selectedItems, clickedItemId ), { by : "cid" } );
-					else this.setSelectedModels( _.union( this.selectedItems, clickedItemId ), { by : "cid" } );
+					else this.setSelectedModels( _.union( this.selectedItems, [clickedItemId] ), { by : "cid" } );
 				}
 				else
 					this.setSelectedModels( [ clickedItemId ], { by : "cid" } );


### PR DESCRIPTION
Toggle functionality not work with underscore >1.6.0. Underscore's method 'union' in version >1.6.0 work with arrays only"