### PR TITLE
modified modelviewconstructor to support supplying a contructor...

### DIFF
--- a/src/backbone.collectionView.js
+++ b/src/backbone.collectionView.js
@@ -675,6 +675,12 @@
 		},
 
 		_getModelViewConstructor : function( thisModel ) {
+                        
+                        // added possibility to supply factory method as modelView param
+                        if (typeof this.modelView === 'function') {
+                            return this.modelView(thisModel);
+                        }
+                        
 			return this.modelView || mDefaultModelViewConstructor;
 		},
 


### PR DESCRIPTION
Hey guys,

Great work on the collectionView. Just added the possibility to supply a method instead of a class as "modelView" in order to support some kind of factory pattern when choosing the view, based on the model data (which is supplied as argument to the method). Thought you might like it. If not that's cool too.

FabScav