### PR TITLE
selectMultiple: allow also Ctrl+Click to toggle selected items

### DIFF
--- a/src/backbone.collectionView.js
+++ b/src/backbone.collectionView.js
@@ -921,7 +921,7 @@
 							sel.removeAllRanges();
 					}
 				}
-				else if( this.selectMultiple && ( this.clickToToggle || theEvent.metaKey ) )
+				else if( this.selectMultiple && ( this.clickToToggle || theEvent.metaKey || theEvent.ctrlKey ) )
 				{
 					if( _.contains( this.selectedItems, clickedItemId ) )
 						this.setSelectedModels( _.without( this.selectedItems, clickedItemId ), { by : "cid" } );


### PR DESCRIPTION
Commonly, Ctrl+Click allows to toggle item selection in selectMultiple environments (at least on Linux/Win).
Thus add this ability to backbone.collectionView.

[TODO: add Ctrl+Shift+Click to extend selection by a range.
Caveat: we'll have to track last clicked item instead of taking first selected as start-item.]