### PR TITLE
Remove deprecated `version` field from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
 	"name" : "backbone.collectionView",
-	"version": "0.12.0",
 	"homepage": "http://rotundasoftware.github.io/backbone.collectionView/",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
https://github.com/bower/spec/blob/master/json.md#version:

> *Deprecated*
> 
> Use git or svn tags instead. This field is ignored by Bower.
