### PR TITLE
Loosen dependency version restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "backbone": "^1.2.3",
-    "jquery": "~2.1.1",
-    "jquery-ui": "~1.10.1"
+    "jquery": "^2.1.1",
+    "jquery-ui": "^1.10.1"
   }
 }


### PR DESCRIPTION
### Problem

Currently this library doesn't support [jQuery v2.2.0](https://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/) because [the `package.json` of this project specifies `jquery` version with `~` operator](https://github.com/rotundasoftware/backbone.collectionView/blob/8b48b69e7ce291f4ba8d9c8b5460a93dfeea75f9/package.json#L33).

### Solution

I replaced `~` with [`^`](https://nodesource.com/blog/semver-tilde-and-caret/) to let this library work with jQuery v2.2.0.
