### PR TITLE
Improvement: add "class" field to init options

### DIFF
--- a/src/backbone.collectionView.js
+++ b/src/backbone.collectionView.js
@@ -62,7 +62,8 @@
 			{ "sortableOptions" : null },
 			{ "reuseModelViews" : true },
 			{ "detachedRendering" : false },
-			{ "emptyListCaption" : null }
+			{ "emptyListCaption" : null },
+			{ "class" : 'selected' }
 		],
 
 		initialize : function( options ) {
@@ -686,6 +687,8 @@
 		},
 
 		_addSelectedClassToSelectedItems : function( oldItemsIdsWithSelectedClass ) {
+			var options = this.getOptions();
+
 			if( _.isUndefined( oldItemsIdsWithSelectedClass ) ) oldItemsIdsWithSelectedClass = [];
 
 			// oldItemsIdsWithSelectedClass is used for optimization purposes only. If this info is supplied then we
@@ -695,10 +698,10 @@
 			itemsIdsFromWhichSelectedClassNeedsToBeRemoved = _.without( itemsIdsFromWhichSelectedClassNeedsToBeRemoved, this.selectedItems );
 
 			_.each( itemsIdsFromWhichSelectedClassNeedsToBeRemoved, function( thisItemId ) {
-				this._getContainerEl().find( "[data-model-cid=" + thisItemId + "]" ).removeClass( "selected" );
+				this._getContainerEl().find( "[data-model-cid=" + thisItemId + "]" ).removeClass( options.class );
 				
 				if( this._isRenderedAsList() ) {
-					this._getContainerEl().find( "li[data-model-cid=" + thisItemId + "] > *" ).removeClass( "selected" );
+					this._getContainerEl().find( "li[data-model-cid=" + thisItemId + "] > *" ).removeClass( options.class );
 				}
 			}, this );
 
@@ -706,10 +709,10 @@
 			itemsIdsFromWhichSelectedClassNeedsToBeAdded = _.without( itemsIdsFromWhichSelectedClassNeedsToBeAdded, oldItemsIdsWithSelectedClass );
 
 			_.each( itemsIdsFromWhichSelectedClassNeedsToBeAdded, function( thisItemId ) {
-				this._getContainerEl().find( "[data-model-cid=" + thisItemId + "]" ).addClass( "selected" );
+				this._getContainerEl().find( "[data-model-cid=" + thisItemId + "]" ).addClass( options.class );
 
 				if( this._isRenderedAsList() ) {
-					this._getContainerEl().find( "li[data-model-cid=" + thisItemId + "] > *" ).addClass( "selected" );
+					this._getContainerEl().find( "li[data-model-cid=" + thisItemId + "] > *" ).addClass( options.class );
 				}
 			}, this );
 		},


### PR DESCRIPTION
Hello guys. 

I'm using your backbone.collectionView (thanks for it!) with Bootstrap Nav component (demo here: http://getbootstrap.com/components/#nav-tabs)

By default, Bootsrtap active tab has "active" class, but your library adds "selected" class to active model view element. So I just added option for selected model class with default value "selected".

Let me know if I did something wrong, on my local projects it works fine now. 
Thanks! 